### PR TITLE
fix: wrong png-path

### DIFF
--- a/src/components/AppUI/index.tsx
+++ b/src/components/AppUI/index.tsx
@@ -21,7 +21,7 @@ export default function AppUI() {
           pb={2}
           boxSize="full"
           objectFit="contain"
-          src={`${window._detectedSiteType.basePath}/images/app-screenshot.png`}
+          src={`${window._detectedSiteType.basePath}/public/images/app-screenshot.png`}
         />
       </Box>
     </Box>


### PR DESCRIPTION
<img width="204" alt="Screenshot 2023-02-15 at 11 37 25" src="https://user-images.githubusercontent.com/81620050/219008380-39fec59f-6c96-4675-b2ee-1126d46cb3fd.png">
this occures at any browser cause wrong path, attempt to fix